### PR TITLE
修正一些小問題

### DIFF
--- a/button.html
+++ b/button.html
@@ -35,7 +35,7 @@
     -->
     <link href="stylesheets/remote_draw.css?v2" media="screen, projection" rel="stylesheet" type="text/css" />
 	<link href="stylesheets/animate.css" media="screen, projection" rel="stylesheet" type="text/css" />
-    <link href='http://fonts.googleapis.com/css?family=Fredoka+One' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Fredoka+One' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="fonts/style.css">
     <script src="javascript/Three.js"></script>
     <script src="javascript/Projector.js"></script>

--- a/button.html
+++ b/button.html
@@ -7,7 +7,7 @@
 	<meta property="og:title" content="Lottery 抽獎系統 - 抽獎按鈕" />
 	<meta property="og:site_name" content="Lottery 抽獎系統 - 抽獎按鈕" />
 	<link rel="shortcut icon" href="/favicon.ico" />
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js" type="text/javascript"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js" type="text/javascript"></script>
     <script type="module">
         import {initializeApp} from "https://www.gstatic.com/firebasejs/9.5.0/firebase-app.js";
         import { getAuth, signInWithEmailAndPassword, signInAnonymously } from "https://www.gstatic.com/firebasejs/9.5.0/firebase-auth.js";

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
 	<meta property="og:site_name" content="Lottery 尾牙抽獎程式！" />
 	<link rel="shortcut icon" href="/favicon.ico" />
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js" type="text/javascript"></script>
-    <link href='//fonts.googleapis.com/css?family=Asap:700' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Fredoka+One' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Asap:700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Fredoka+One' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="fonts/style.css">
 	<link href="stylesheets/animate.css" media="screen, projection" rel="stylesheet" type="text/css" />
     <script type="module">

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 	<meta property="og:image" content="" />
 	<meta property="og:site_name" content="Lottery 尾牙抽獎程式！" />
 	<link rel="shortcut icon" href="/favicon.ico" />
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js" type="text/javascript"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js" type="text/javascript"></script>
     <link href='//fonts.googleapis.com/css?family=Asap:700' rel='stylesheet' type='text/css'>
     <link href='http://fonts.googleapis.com/css?family=Fredoka+One' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="fonts/style.css">

--- a/javascript/controller.js
+++ b/javascript/controller.js
@@ -1676,7 +1676,7 @@ $.when(
                         //在 ps-page 下列出可不在現場原因
                         var ps_item = _tpl.ps_data.clone().appendTo('.ps-noshow-list');
                         ps_item.find('.ps-id').text(++noshow_count);
-                        ps_item.find('.ps-sn').text(ps_user[1]);
+                        ps_item.find('.ps-sn').text(String(ps_user[1]).padStart(6,'0'));
                         ps_item.find('.ps-content').text(user.gone_ok);
                     }
                     var skip_gift_array = [];
@@ -1687,7 +1687,7 @@ $.when(
                                 //在 ps-page 下列出該員工只能領取的獎項清單
                                 var ps_item = _tpl.ps_data.clone().appendTo('.ps-only-list');
                                 ps_item.find('.ps-id').text(++only_count);
-                                ps_item.find('.ps-sn').text(ps_user[1]);
+                                ps_item.find('.ps-sn').text(String(ps_user[1]).padStart(6,'0'));
                                 ps_item.find('.ps-content').text(user.allow_gift.replace(/\|/g, ' '));
                             }
                             continue;
@@ -1702,7 +1702,7 @@ $.when(
                         //在 ps-page 下列出必需 skip 的獎項清單
                         var ps_item = _tpl.ps_data.clone().appendTo('.ps-skip-list');
                         ps_item.find('.ps-id').text(++skip_count);
-                        ps_item.find('.ps-sn').text(ps_user[1]);
+                        ps_item.find('.ps-sn').text(String(ps_user[1]).padStart(6,'0'));
                         ps_item.find('.ps-content').text(skip_gift_array.join(' '));
                     }
                 }


### PR DESCRIPTION
### Github Page修正
透過http引入jquery與google fonts會發生錯誤:
> Mixed Content: The page at 'https://grassboy.github.io/Lottery/' was loaded over HTTPS, but requested an insecure script 'http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js'. This request has been blocked; the content must be served over HTTPS.

> Mixed Content: The page at 'https://grassboy.github.io/Lottery/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Fredoka+One'. This request has been blocked; the content must be served over HTTPS.

修改為https之後，index.html和button.html皆恢復正常。
(如果只有在本機localhost使用不影響程式運作，但無法使用遠端抽獎按鈕)

### 可不在現場員工清單員工編號前綴補零
Github顯示的diff怪怪的，實際修改的部分只有processPSData的其中三行
```js
ps_item.find('.ps-sn').text(ps_user[1]);
```
改成
```js
ps_item.find('.ps-sn').text(String(ps_user[1]).padStart(6,'0'));
```